### PR TITLE
Use golang:1.16.6 instead of latest golang:1.16 to fix libpcap issue temporary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 as build
+FROM golang:1.16.6 as build
 
 RUN apt-get update && apt-get -y install libpcap-dev
 


### PR DESCRIPTION
### Required for all PRs:

Failed to build due to libpcap prob:

```
#19 123.9 # github.com/influxdata/telegraf/cmd/telegraf
#19 123.9 /usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
#19 123.9 /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/10/../../../x86_64-linux-gnu/libpcap.a(nametoaddr.o): in function `pcap_nametoaddrinfo':
#19 123.9 (.text+0x83): warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
#19 123.9 /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/10/../../../x86_64-linux-gnu/libpcap.a(nametoaddr.o): in function `pcap_nametoaddr':
#19 123.9 (.text+0x5): warning: Using 'gethostbyname' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
#19 123.9 /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/10/../../../x86_64-linux-gnu/libpcap.a(nametoaddr.o): in function `pcap_nametonetaddr':
#19 123.9 (.text+0xed): warning: Using 'getnetbyname_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
#19 123.9 /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/10/../../../x86_64-linux-gnu/libpcap.a(nametoaddr.o): in function `pcap_nametoproto':
#19 123.9 (.text+0x54f): warning: Using 'getprotobyname_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
#19 123.9 /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/10/../../../x86_64-linux-gnu/libpcap.a(pcap-dbus.o): in function `dbus_write':
#19 123.9 (.text+0xff): undefined reference to `dbus_message_demarshal'
#19 123.9 /usr/bin/ld: (.text+0x115): undefined reference to `dbus_connection_send'
#19 123.9 /usr/bin/ld: (.text+0x11e): undefined reference to `dbus_connection_flush'
#19 123.9 /usr/bin/ld: (.text+0x126): undefined reference to `dbus_message_unref'
#19 123.9 /usr/bin/ld: (.text+0x174): undefined reference to `dbus_error_free'
#19 123.9 /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/10/../../../x86_64-linux-gnu/libpcap.a(pcap-dbus.o): in function `dbus_read':
#19 123.9 (.text+0x1bf): undefined reference to `dbus_connection_pop_message'
#19 123.9 /usr/bin/ld: (.text+0x1e1): undefined reference to `dbus_connection_pop_message'
#19 123.9 /usr/bin/ld: (.text+0x1f6): undefined reference to `dbus_connection_read_write'
#19 123.9 /usr/bin/ld: (.text+0x262): undefined reference to `dbus_message_is_signal'
#19 123.9 /usr/bin/ld: (.text+0x27f): undefined reference to `dbus_message_marshal'
#19 123.9 /usr/bin/ld: (.text+0x2e3): undefined reference to `dbus_free'
#19 123.9 /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/10/../../../x86_64-linux-gnu/libpcap.a(pcap-dbus.o): in function `dbus_cleanup':
#19 123.9 (.text+0x34c): undefined reference to `dbus_connection_unref'
#19 123.9 /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/10/../../../x86_64-linux-gnu/libpcap.a(pcap-dbus.o): in function `dbus_activate':
#19 123.9 (.text+0x406): undefined reference to `dbus_connection_open'
#19 123.9 /usr/bin/ld: (.text+0x41e): undefined reference to `dbus_bus_register'
#19 123.9 /usr/bin/ld: (.text+0x511): undefined reference to `dbus_bus_add_match'
#19 123.9 /usr/bin/ld: (.text+0x519): undefined reference to `dbus_error_is_set'
#19 123.9 /usr/bin/ld: (.text+0x54b): undefined reference to `dbus_bus_get'
#19 123.9 /usr/bin/ld: (.text+0x57c): undefined reference to `dbus_error_free'
#19 123.9 /usr/bin/ld: (.text+0x58c): undefined reference to `dbus_bus_add_match'
#19 123.9 /usr/bin/ld: (.text+0x594): undefined reference to `dbus_error_is_set'
#19 123.9 /usr/bin/ld: (.text+0x5c9): undefined reference to `dbus_error_free'
#19 123.9 /usr/bin/ld: (.text+0x5d5): undefined reference to `dbus_connection_unref'
#19 123.9 /usr/bin/ld: (.text+0x62e): undefined reference to `dbus_bus_get'
#19 123.9 /usr/bin/ld: (.text+0x66a): undefined reference to `dbus_error_free'
#19 123.9 /usr/bin/ld: (.text+0x681): undefined reference to `dbus_connection_set_max_received_size'
#19 123.9 /usr/bin/ld: (.text+0x696): undefined reference to `dbus_connection_unref'
#19 123.9 /usr/bin/ld: (.text+0x714): undefined reference to `dbus_error_free'
#19 123.9 collect2: error: ld returned 1 exit status
#19 123.9
#19 124.4 make: *** [Makefile:93: telegraf] Error 2
```

golang:1.16.6
```
root@dba832586868:/go# apt-cache policy libpcap-dev
libpcap-dev:
  Installed: (none)
  Candidate: 1.8.1-6
  Version table:
     1.8.1-6 500
        500 http://deb.debian.org/debian buster/main amd64 Packages
```

golang:1.16.7
```
root@9f54e802d715:/app# apt-cache policy libpcap-dev
libpcap-dev:
  Installed: 1.10.0-2
  Candidate: 1.10.0-2
  Version table:
 *** 1.10.0-2 500
        500 http://deb.debian.org/debian bullseye/main amd64 Packages
        100 /var/lib/dpkg/status
```
