### PR TITLE
enhance version naming

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,8 +2,7 @@
 
 set -o errexit -o nounset -o pipefail
 
-v="$(head -n 1 VERSION)"
-v="${v}-$(date '+%Y%m%d')-$(git rev-parse --short HEAD)"
+v="$(./scripts/make-version.sh tag)"
 
 echo "version=${v}"
 

--- a/scripts/make-version.sh
+++ b/scripts/make-version.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# This script generates semver version by the following rules in order of priority from top to bottom
+# 1. the environment variable `VERSION`
+# 2. take tag name when the HEAD matches any tag
+# 3. take x.x when the HEAD matches branch named as release/x.x
+# 4. VERSION file content which indicates the next version
+
+set -o errexit
+
+function get_version() {
+  [[ -n "${VERSION}" ]] && echo "${VERSION/v/}" && return
+  [[ -f VERSION ]] && ver=$(head -n 1 VERSION) || ver=0.0
+  ALPHA=${ver}.0-alpha
+  HEAD_TAG=$(git tag --points-at HEAD |head -n1)
+  # remove prefix v when present
+  [[ -n "${HEAD_TAG}" ]] && echo "${HEAD_TAG/v/}" && return
+
+  BRANCH_PREFIX=$(git rev-parse --abbrev-ref HEAD)
+
+  if [[ "${BRANCH_PREFIX}" =~ release/[[:digit:]]+\.* ]]; then
+    VERSION="${BRANCH_PREFIX//release\//}.0-beta"
+  fi
+
+  echo ${VERSION:-${ALPHA}}
+}
+
+function get_tag() {
+  ver=$(get_version)
+  if ! [[ "${ver}" =~ - ]]; then
+    ver="${ver}-stable"
+  fi
+  echo "${ver}-$(date '+%Y%m%d%H%M%S')-$(git rev-parse --short HEAD)"
+}
+
+case $1 in
+tag)
+  get_tag
+  ;;
+*)
+  get_version
+esac


### PR DESCRIPTION
This make-version.sh script generates semver version by the following rules in order of priority from top to bottom
1. the environment variable `VERSION`
2. take tag name when the HEAD matches any tag
3. take x.x when the HEAD matches branch named as release/x.x
4. VERSION file content which indicates the next version

For instance,

1. version would be 1.2.1 after `git checkout v1.2.1`
2. version would be 1.2.0-beta after `git checkout release/1.2`
3. version would be 1.3.0-alpha after `git checkout master`

more info: [改进镜像 version 前缀生成方式](https://erda.cloud/erda/dop/projects/387/issues/all?id=203991&issueFilter__urlQuery=eyJ0aXRsZSI6InZlcnNpb24iLCJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6InRhYmxlIiwiY2hpbGRyZW5WYWx1ZSI6eyJrYW5iYW4iOiJkZWFkbGluZSJ9fQ%3D%3D&iterationID=506&type=REQUIREMENT)

related: https://github.com/erda-project/erda/pull/1562

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
