### PR TITLE
Fix interface conversion

### DIFF
--- a/plugins/processors/application_slow/application_slow.go
+++ b/plugins/processors/application_slow/application_slow.go
@@ -38,7 +38,11 @@ func (d *ApplicationSlow) Apply(in ...telegraf.Metric) []telegraf.Metric {
 		if !ok {
 			continue
 		}
-		elapsed := int64(value.(float64))
+
+		elapsed, ok := value.(int64)
+		if !ok {
+			elapsed = int64(value.(float64))
+		}
 
 		// tag中包含error，并且值为true，创建application_*_error的 metric，并且保留request_id
 		if errorVal, ok := metric.GetTag("error"); ok {


### PR DESCRIPTION
Fix bug 
```
panic: interface conversion: interface {} is int64, not float64
goroutine 100 [running]:
github.com/influxdata/telegraf/plugins/processors/application_slow.(*ApplicationSlow).Apply(0xc0003f2b70, 0xc00129f200, 0x1, 0x1, 0xc00129f1e0, 0xc001305ed8, 0x7c2b8a)
	/root/build/plugins/processors/application_slow/application_slow.go:41 +0xb59
github.com/influxdata/telegraf/plugins/processors.(*streamingProcessor).Add(0xc0009d09f0, 0x53ab8f0, 0xc000f650e0, 0x53972f8, 0xc00062a160, 0x1, 0x101)
	/root/build/plugins/processors/streamingprocessor.go:37 +0x82
github.com/influxdata/telegraf/models.(*RunningProcessor).Add(0xc0009d0b40, 0x53ab8f0, 0xc000f650e0, 0x53972f8, 0xc00062a160, 0x0, 0x0)
	/root/build/models/running_processor.go:95 +0x108
github.com/influxdata/telegraf/agent.(*Agent).runProcessors.func1(0xc000da20b0, 0xc0009e01b0)
	/root/build/agent/agent.go:544 +0x157
created by github.com/influxdata/telegraf/agent.(*Agent).runProcessors
	/root/build/agent/agent.go:539 +0x91
```